### PR TITLE
Resolve ambiguous import for LoginPage

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,8 +5,8 @@ import 'package:http/http.dart' as http;
 
 import 'services/api_client.dart';
 import 'services/wallet_service.dart';
-import 'pages/login_page.dart';
-import 'pages/home_page.dart';
+import 'pages/login_page.dart' show LoginPage;
+import 'pages/home_page.dart' show HomePage;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Resolve ambiguous import of `LoginPage` by specifying `show` clauses in `main.dart`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7ba2dc1-7ed0-4ac0-974e-4799b1cd8dfb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7ba2dc1-7ed0-4ac0-974e-4799b1cd8dfb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

